### PR TITLE
gracefully handle api limit when uploading vectors

### DIFF
--- a/app/controller/controller.py
+++ b/app/controller/controller.py
@@ -3,12 +3,17 @@ from collections.abc import AsyncGenerator
 from random import random
 
 from app.interfaces import AIAgentInterface, DatabaseManagerInterface
-from app.interfaces.errors import TooManyRequestsError
+from app.interfaces.errors import EmbeddingAPILimitError, TooManyRequestsError
 
 
 async def add_content_into_db(db: DatabaseManagerInterface, content: str):
-    async for percentage in db.add_text_to_db(content):
-        yield f"{percentage}\n"
+    try:
+        async for percentage in db.add_text_to_db(content):
+            yield f"{percentage}\n"
+    except EmbeddingAPILimitError:
+        # Return a special signal to indicate API limit reached
+        # The frontend should look for this specific string
+        yield "API_LIMIT_EXCEEDED\n"
 
 
 async def query_agent(

--- a/app/databases/chroma_database.py
+++ b/app/databases/chroma_database.py
@@ -12,7 +12,7 @@ from langchain_community.document_loaders import DirectoryLoader
 from langchain_core.documents.base import Document
 
 from app.interfaces.database import DatabaseManagerInterface
-from app.interfaces.errors import TooManyRequestsError
+from app.interfaces.errors import EmbeddingAPILimitError, TooManyRequestsError
 
 load_dotenv()
 
@@ -51,13 +51,32 @@ class ChromaDatabase(DatabaseManagerInterface):
 
     async def add_text_to_db(self, text: str) -> AsyncIterator[float]:
         chunks = [Document(chunk) for chunk in self.text_splitter.split_text(text)]
+        uploaded_chunk_ids = []
+
         try:
             for progress, chunk in enumerate(chunks):
-                await self.db.aadd_documents([chunk])
+                # Add document and capture the IDs for potential rollback
+                result = await self.db.aadd_documents([chunk])
+                if hasattr(result, "ids") and result.ids:
+                    uploaded_chunk_ids.extend(result.ids)
                 yield (progress + 1) / len(chunks) * 100
 
         except CohereTooManyRequestsError as err:
-            raise TooManyRequestsError(content=err.body)
+            # If we have uploaded chunks, we need to roll them back
+            if uploaded_chunk_ids:
+                await self._rollback_chunks(uploaded_chunk_ids)
+            raise EmbeddingAPILimitError(content=err.body, chunks_uploaded=len(uploaded_chunk_ids))
+
+
+    async def _rollback_chunks(self, chunk_ids: list[str]) -> None:
+        """Remove uploaded chunks from the database"""
+        try:
+            # Remove the uploaded documents by their IDs
+            self.db.delete(ids=chunk_ids)
+        except Exception:
+            # If rollback fails, we log it but don't raise another exception
+            # to avoid masking the original API limit error
+            pass
 
     def get_chunks(self) -> list[str]:
         return self.db.get()["documents"]

--- a/app/interfaces/errors.py
+++ b/app/interfaces/errors.py
@@ -4,3 +4,13 @@ class TooManyRequestsError(Exception):
 
     def __init__(self, content: any = None):
         self.content = content
+
+
+class EmbeddingAPILimitError(Exception):
+    """Raised when the embedding API limit is reached during document upload"""
+    status_code: int = 429
+    content: any
+
+    def __init__(self, content: any = None, chunks_uploaded: int = 0):
+        self.content = content
+        self.chunks_uploaded = chunks_uploaded


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Uploads now detect embedding API rate limits and show a clear in-app warning with yellow styling and guidance; progress stops and a warning toast is displayed.

- Bug Fixes
  - Prevents partial uploads from persisting when API limits are hit, avoiding confusing progress states and ensuring data consistency.

- Tests
  - Added tests covering partial and immediate API-limit scenarios to verify graceful signaling and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->